### PR TITLE
Update to explanation area UI/formatting

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,6 +42,8 @@ dependencies {
     implementation("com.squareup.okhttp3:okhttp:4.9.3")
     implementation("com.squareup.okhttp3:okhttp-sse:4.9.3")
 
+    implementation("com.vladsch.flexmark:flexmark-all:0.62.2")
+
     testImplementation("io.mockk:mockk:1.12.0")
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,7 +42,7 @@ dependencies {
     implementation("com.squareup.okhttp3:okhttp:4.9.3")
     implementation("com.squareup.okhttp3:okhttp-sse:4.9.3")
 
-    implementation("com.vladsch.flexmark:flexmark-all:0.62.2")
+    implementation("com.vladsch.flexmark:flexmark-all:0.64.8")
 
     testImplementation("io.mockk:mockk:1.12.0")
 }

--- a/src/main/kotlin/dev/jamiecraane/gptmentorplugin/ui/chat/ChatPanel.kt
+++ b/src/main/kotlin/dev/jamiecraane/gptmentorplugin/ui/chat/ChatPanel.kt
@@ -162,7 +162,9 @@ class ChatPanel(mainPresenter: MainPresenter) : JPanel(), ChatView {
     }
 
     override fun appendToExplanation(message: String) {
-        // TODO: Add message to chat bubble
+        ApplicationManager.getApplication().invokeLater {
+            chatBubbles.newBubble(message)
+        }
 
     }
 

--- a/src/main/kotlin/dev/jamiecraane/gptmentorplugin/ui/chat/ChatPanel.kt
+++ b/src/main/kotlin/dev/jamiecraane/gptmentorplugin/ui/chat/ChatPanel.kt
@@ -16,7 +16,11 @@ import javax.swing.*
 import javax.swing.event.DocumentEvent
 import javax.swing.event.DocumentListener
 import javax.swing.text.StyledDocument
+import com.vladsch.flexmark.parser.Parser
+import com.vladsch.flexmark.util.ast.Node
+import com.vladsch.flexmark.html.HtmlRenderer
 import dev.jamiecraane.gptmentorplugin.ui.chat.messages.ChatBubbleGroup
+
 
 class ChatPanel(mainPresenter: MainPresenter) : JPanel(), ChatView {
     val presenter = ChatPresenter(this, mainPresenter)
@@ -186,7 +190,7 @@ class ChatPanel(mainPresenter: MainPresenter) : JPanel(), ChatView {
     }
 
     override fun clearExplanation() {
-        // TODO: delete all chat bubbles
+        chatBubbles.myList.removeAll()
     }
 
     override fun showError(message: String) {

--- a/src/main/kotlin/dev/jamiecraane/gptmentorplugin/ui/chat/ChatPanel.kt
+++ b/src/main/kotlin/dev/jamiecraane/gptmentorplugin/ui/chat/ChatPanel.kt
@@ -3,22 +3,20 @@ package dev.jamiecraane.gptmentorplugin.ui.chat
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
 import com.intellij.ui.AnimatedIcon
-import com.intellij.ui.JBColor
 import com.intellij.ui.components.JBLabel
 import com.intellij.ui.components.JBScrollPane
 import com.intellij.ui.components.JBTextArea
-import dev.jamiecraane.gptmentorplugin.common.extensions.addNewLinesIfNeeded
 import dev.jamiecraane.gptmentorplugin.common.extensions.onKeyPressed
+import dev.jamiecraane.gptmentorplugin.ui.chat.messages.ChatBubble
 import dev.jamiecraane.gptmentorplugin.ui.main.MainPresenter
 import java.awt.BorderLayout
-import java.awt.Color
 import java.awt.Dimension
 import java.awt.event.KeyEvent
 import javax.swing.*
 import javax.swing.event.DocumentEvent
 import javax.swing.event.DocumentListener
-import javax.swing.text.StyleConstants
 import javax.swing.text.StyledDocument
+import dev.jamiecraane.gptmentorplugin.ui.chat.messages.ChatBubbleGroup
 
 class ChatPanel(mainPresenter: MainPresenter) : JPanel(), ChatView {
     val presenter = ChatPresenter(this, mainPresenter)
@@ -52,6 +50,8 @@ class ChatPanel(mainPresenter: MainPresenter) : JPanel(), ChatView {
             }
         })
     }
+
+    private val chatBubbles = ChatBubbleGroup()
 
 
     init {
@@ -151,8 +151,8 @@ class ChatPanel(mainPresenter: MainPresenter) : JPanel(), ChatView {
     }
 
     private fun createExplanationScrollPane(): JBScrollPane {
-        // TODO: add the MessageGroupComponent & default chat bubble
-        return JBScrollPane(JLabel("Empty Area"))
+        chatBubbles.add(ChatBubble(INTRO_MESSAGE, false))
+        return JBScrollPane(chatBubbles.myList).apply { horizontalScrollBarPolicy = JScrollPane.HORIZONTAL_SCROLLBAR_NEVER }
     }
 
     private fun createHorizontalBoxPanel(): JPanel {

--- a/src/main/kotlin/dev/jamiecraane/gptmentorplugin/ui/chat/ChatPanel.kt
+++ b/src/main/kotlin/dev/jamiecraane/gptmentorplugin/ui/chat/ChatPanel.kt
@@ -194,7 +194,12 @@ class ChatPanel(mainPresenter: MainPresenter) : JPanel(), ChatView {
     }
 
     override fun appendExplanation(explanation: String) {
-        // TODO: Add explanation to existing chat bubble
+        ApplicationManager.getApplication().invokeLater {
+            chatBubbles.lastComponent?.let {
+                if (it.isUser) chatBubbles.newBubble(explanation, false)
+                else it.appendMessage(explanation)
+            }
+        }
     }
 
     override fun showLoading() {

--- a/src/main/kotlin/dev/jamiecraane/gptmentorplugin/ui/chat/ChatPanel.kt
+++ b/src/main/kotlin/dev/jamiecraane/gptmentorplugin/ui/chat/ChatPanel.kt
@@ -53,33 +53,6 @@ class ChatPanel(mainPresenter: MainPresenter) : JPanel(), ChatView {
         })
     }
 
-//    private val explanationArea = JTextPane().apply {
-//        border = BorderFactory.createEmptyBorder(10, 10, 10, 10)
-//        isEditable = false
-//    }
-
-//    private val userStyle = explanationArea.addStyle("User", null).apply {
-//        StyleConstants.setFontFamily(this, "Menlo");
-//        StyleConstants.setFontSize(this, 14);
-//        StyleConstants.setForeground(
-//            this, JBColor(
-//                Color(77, 111, 151),
-//                Color(115, 170, 212)
-//            )
-//        );
-//    }
-
-//    private val systemStyle = explanationArea.addStyle("System", null).apply {
-//        StyleConstants.setFontFamily(this, "Menlo");
-//        StyleConstants.setFontSize(this, 14);
-//        StyleConstants.setForeground(
-//            this,
-//            JBColor(
-//                Color(103, 81, 111),
-//                Color(187, 134, 206)
-//            )
-//        );
-//    }
 
     init {
         layout = BorderLayout()
@@ -191,11 +164,6 @@ class ChatPanel(mainPresenter: MainPresenter) : JPanel(), ChatView {
     override fun appendToExplanation(message: String) {
         // TODO: Add message to chat bubble
 
-//        ApplicationManager.getApplication().invokeLater {
-//            val doc = explanationArea.styledDocument
-//            val withNewlines = message.addNewLinesIfNeeded(2)
-//            doc.insertString(explanationArea.styledDocument.length, withNewlines, userStyle)
-//        }
     }
 
     override fun appendToPrompt(text: String) {
@@ -254,7 +222,6 @@ class ChatPanel(mainPresenter: MainPresenter) : JPanel(), ChatView {
 
     override fun onExplanationDone() {
         ApplicationManager.getApplication().invokeLater {
-//            explanationArea.styledDocument.addNewLines(2)
             promptTextArea.text = ""
         }
         setFocusOnPrompt()

--- a/src/main/kotlin/dev/jamiecraane/gptmentorplugin/ui/chat/ChatPanel.kt
+++ b/src/main/kotlin/dev/jamiecraane/gptmentorplugin/ui/chat/ChatPanel.kt
@@ -15,10 +15,6 @@ import java.awt.event.KeyEvent
 import javax.swing.*
 import javax.swing.event.DocumentEvent
 import javax.swing.event.DocumentListener
-import javax.swing.text.StyledDocument
-import com.vladsch.flexmark.parser.Parser
-import com.vladsch.flexmark.util.ast.Node
-import com.vladsch.flexmark.html.HtmlRenderer
 import dev.jamiecraane.gptmentorplugin.ui.chat.messages.ChatBubbleGroup
 
 
@@ -246,12 +242,6 @@ class ChatPanel(mainPresenter: MainPresenter) : JPanel(), ChatView {
 
     override fun updateNumberOfTokens(label: String) {
         numberOfTokens.text = label
-    }
-
-    private fun StyledDocument.addNewLines(numberOfLines: Int) {
-        val docLength = length
-        val newLines = "\n".repeat(numberOfLines)
-        insertString(docLength, newLines, null)
     }
 
     companion object {

--- a/src/main/kotlin/dev/jamiecraane/gptmentorplugin/ui/chat/ChatPanel.kt
+++ b/src/main/kotlin/dev/jamiecraane/gptmentorplugin/ui/chat/ChatPanel.kt
@@ -24,6 +24,8 @@ class ChatPanel(mainPresenter: MainPresenter) : JPanel(), ChatView {
     private val submitButton = JButton("Submit")
     private val numberOfTokens = JLabel("")
 
+    private lateinit var explanationScrollPane : JBScrollPane
+
     private val promptTextArea = JBTextArea(INTRO_MESSAGE).apply {
         lineWrap = true
         minimumSize = Dimension(Integer.MAX_VALUE, PROMPT_MAX_HEIGHT)
@@ -83,7 +85,7 @@ class ChatPanel(mainPresenter: MainPresenter) : JPanel(), ChatView {
         promptPanel.add(Box.createVerticalStrut(10))
         createExplanationLabelPanel().also { promptPanel.add(it) }
         promptPanel.add(Box.createVerticalStrut(10))
-        val explanationScrollPane = createExplanationScrollPane()
+        explanationScrollPane = createExplanationScrollPane()
         promptPanel.add(explanationScrollPane)
 
         return promptPanel
@@ -164,7 +166,9 @@ class ChatPanel(mainPresenter: MainPresenter) : JPanel(), ChatView {
     override fun appendToExplanation(message: String) {
         ApplicationManager.getApplication().invokeLater {
             chatBubbles.newBubble(message)
+            explanationScrollPane.verticalScrollBar.value = explanationScrollPane.verticalScrollBar.maximum
         }
+
 
     }
 
@@ -199,6 +203,7 @@ class ChatPanel(mainPresenter: MainPresenter) : JPanel(), ChatView {
                 if (it.isUser) chatBubbles.newBubble(explanation, false)
                 else it.appendMessage(explanation)
             }
+            explanationScrollPane.verticalScrollBar.value = explanationScrollPane.verticalScrollBar.maximum
         }
     }
 

--- a/src/main/kotlin/dev/jamiecraane/gptmentorplugin/ui/chat/ChatPanel.kt
+++ b/src/main/kotlin/dev/jamiecraane/gptmentorplugin/ui/chat/ChatPanel.kt
@@ -53,33 +53,33 @@ class ChatPanel(mainPresenter: MainPresenter) : JPanel(), ChatView {
         })
     }
 
-    private val explanationArea = JTextPane().apply {
-        border = BorderFactory.createEmptyBorder(10, 10, 10, 10)
-        isEditable = false
-    }
+//    private val explanationArea = JTextPane().apply {
+//        border = BorderFactory.createEmptyBorder(10, 10, 10, 10)
+//        isEditable = false
+//    }
 
-    private val userStyle = explanationArea.addStyle("User", null).apply {
-        StyleConstants.setFontFamily(this, "Menlo");
-        StyleConstants.setFontSize(this, 14);
-        StyleConstants.setForeground(
-            this, JBColor(
-                Color(77, 111, 151),
-                Color(115, 170, 212)
-            )
-        );
-    }
+//    private val userStyle = explanationArea.addStyle("User", null).apply {
+//        StyleConstants.setFontFamily(this, "Menlo");
+//        StyleConstants.setFontSize(this, 14);
+//        StyleConstants.setForeground(
+//            this, JBColor(
+//                Color(77, 111, 151),
+//                Color(115, 170, 212)
+//            )
+//        );
+//    }
 
-    private val systemStyle = explanationArea.addStyle("System", null).apply {
-        StyleConstants.setFontFamily(this, "Menlo");
-        StyleConstants.setFontSize(this, 14);
-        StyleConstants.setForeground(
-            this,
-            JBColor(
-                Color(103, 81, 111),
-                Color(187, 134, 206)
-            )
-        );
-    }
+//    private val systemStyle = explanationArea.addStyle("System", null).apply {
+//        StyleConstants.setFontFamily(this, "Menlo");
+//        StyleConstants.setFontSize(this, 14);
+//        StyleConstants.setForeground(
+//            this,
+//            JBColor(
+//                Color(103, 81, 111),
+//                Color(187, 134, 206)
+//            )
+//        );
+//    }
 
     init {
         layout = BorderLayout()
@@ -178,7 +178,8 @@ class ChatPanel(mainPresenter: MainPresenter) : JPanel(), ChatView {
     }
 
     private fun createExplanationScrollPane(): JBScrollPane {
-        return JBScrollPane(explanationArea)
+        // TODO: add the MessageGroupComponent & default chat bubble
+        return JBScrollPane(JLabel("Empty Area"))
     }
 
     private fun createHorizontalBoxPanel(): JPanel {
@@ -188,11 +189,13 @@ class ChatPanel(mainPresenter: MainPresenter) : JPanel(), ChatView {
     }
 
     override fun appendToExplanation(message: String) {
-        ApplicationManager.getApplication().invokeLater {
-            val doc = explanationArea.styledDocument
-            val withNewlines = message.addNewLinesIfNeeded(2)
-            doc.insertString(explanationArea.styledDocument.length, withNewlines, userStyle)
-        }
+        // TODO: Add message to chat bubble
+
+//        ApplicationManager.getApplication().invokeLater {
+//            val doc = explanationArea.styledDocument
+//            val withNewlines = message.addNewLinesIfNeeded(2)
+//            doc.insertString(explanationArea.styledDocument.length, withNewlines, userStyle)
+//        }
     }
 
     override fun appendToPrompt(text: String) {
@@ -213,21 +216,15 @@ class ChatPanel(mainPresenter: MainPresenter) : JPanel(), ChatView {
     }
 
     override fun clearExplanation() {
-        ApplicationManager.getApplication().invokeLater {
-            explanationArea.text = ""
-        }
+        // TODO: delete all chat bubbles
     }
 
     override fun showError(message: String) {
-        ApplicationManager.getApplication().invokeLater {
-            explanationArea.text = message
-        }
+        // TODO: Add error to a new chat bubble
     }
 
     override fun appendExplanation(explanation: String) {
-        ApplicationManager.getApplication().invokeLater {
-            explanationArea.styledDocument.insertString(explanationArea.styledDocument.length, explanation, systemStyle)
-        }
+        // TODO: Add explanation to existing chat bubble
     }
 
     override fun showLoading() {
@@ -247,7 +244,7 @@ class ChatPanel(mainPresenter: MainPresenter) : JPanel(), ChatView {
     override fun clearAll() {
         ApplicationManager.getApplication().invokeLater {
             promptTextArea.text = ""
-            explanationArea.text = ""
+            clearExplanation()
         }
     }
 
@@ -257,7 +254,7 @@ class ChatPanel(mainPresenter: MainPresenter) : JPanel(), ChatView {
 
     override fun onExplanationDone() {
         ApplicationManager.getApplication().invokeLater {
-            explanationArea.styledDocument.addNewLines(2)
+//            explanationArea.styledDocument.addNewLines(2)
             promptTextArea.text = ""
         }
         setFocusOnPrompt()

--- a/src/main/kotlin/dev/jamiecraane/gptmentorplugin/ui/chat/ChatPresenter.kt
+++ b/src/main/kotlin/dev/jamiecraane/gptmentorplugin/ui/chat/ChatPresenter.kt
@@ -124,8 +124,14 @@ class ChatPresenter(
     }
 
     private fun handleResponse(streamingResponse: StreamingResponse) {
+        var allData = ""
+        var temp = ""
         when (streamingResponse) {
-            is StreamingResponse.Data -> handleData(streamingResponse.data)
+            is StreamingResponse.Data -> {
+                temp = streamingResponse.data
+                allData += temp
+                handleData(temp)
+            }
             is StreamingResponse.Error -> handleError(streamingResponse.error)
             StreamingResponse.Done -> handleDone()
         }

--- a/src/main/kotlin/dev/jamiecraane/gptmentorplugin/ui/chat/ChatPresenter.kt
+++ b/src/main/kotlin/dev/jamiecraane/gptmentorplugin/ui/chat/ChatPresenter.kt
@@ -102,7 +102,8 @@ class ChatPresenter(
         charsTyped.clear()
         apiJob?.cancel()
         apiJob = scope.launch {
-            chatView.appendToExplanation(prompt.action.addNewLinesIfNeeded(1))
+            chatView.appendToExplanation(prompt.action)
+//            chatView.appendToExplanation(prompt.action.addNewLinesIfNeeded(1))
             kotlin.runCatching {
                 val state = GptMentorSettingsState.getInstance()
                 val chatGptRequest = prompt.createRequest(
@@ -189,11 +190,13 @@ class ChatPresenter(
                     context.chat.messages.forEach { message ->
                         when (message.role) {
                             ChatGptRequest.Message.Role.USER -> {
-                                chatView.appendToExplanation(message.content.addNewLinesIfNeeded(2))
+                                chatView.appendToExplanation(message.content)
+//                                chatView.appendToExplanation(message.content.addNewLinesIfNeeded(2))
                             }
 
                             ChatGptRequest.Message.Role.SYSTEM -> {
-                                chatView.appendExplanation(message.content.addNewLinesIfNeeded(2))
+                                chatView.appendExplanation(message.content)
+//                                chatView.appendExplanation(message.content.addNewLinesIfNeeded(2))
                             }
                         }
                     }

--- a/src/main/kotlin/dev/jamiecraane/gptmentorplugin/ui/chat/messages/ChatBubble.kt
+++ b/src/main/kotlin/dev/jamiecraane/gptmentorplugin/ui/chat/messages/ChatBubble.kt
@@ -8,10 +8,14 @@ import java.awt.BorderLayout
 import java.awt.Component
 import javax.swing.JEditorPane
 import javax.swing.JPanel
+import javax.swing.JTextArea
 
 class ChatBubble (msg : String, user : Boolean = true): JBPanel<ChatBubble>() {
-    private val component = MessagePanel()
     val isUser = user
+    private val responseComponent = MessagePanel()
+    private val questionComponent = JTextArea()
+
+
 
 
 
@@ -33,20 +37,25 @@ class ChatBubble (msg : String, user : Boolean = true): JBPanel<ChatBubble>() {
     }
 
     fun createContentComponent(content :String) : Component {
+        val component = if (isUser) questionComponent else responseComponent
+        responseComponent.contentType = "text/html; charset=UTF-8"
+        responseComponent.updateMessage(content)
+        questionComponent.append(content)
+        questionComponent.lineWrap = true
+        questionComponent.wrapStyleWord = true
+
         component.isEditable = false
         component.putClientProperty(JEditorPane.HONOR_DISPLAY_PROPERTIES, java.lang.Boolean.TRUE)
-        component.contentType = "text/html; charset=UTF-8"
         component.isOpaque = false
         component.border = null
-
-        component.updateMessage(content)
         component.revalidate()
         component.repaint()
+
         return component
     }
 
     fun appendMessage(data: String) {
-        component.appendMessage(data)
+        responseComponent.appendMessage(data)
     }
 
 }

--- a/src/main/kotlin/dev/jamiecraane/gptmentorplugin/ui/chat/messages/ChatBubble.kt
+++ b/src/main/kotlin/dev/jamiecraane/gptmentorplugin/ui/chat/messages/ChatBubble.kt
@@ -9,16 +9,18 @@ import java.awt.Component
 import javax.swing.JEditorPane
 import javax.swing.JPanel
 
-class ChatBubble (msg : String, me : Boolean = true): JBPanel<ChatBubble>() {
+class ChatBubble (msg : String, user : Boolean = true): JBPanel<ChatBubble>() {
     private val component = MessagePanel()
+    val isUser = user
+
 
 
 
     init {
-        var question : String = msg
+        val question : String = msg
 
         isOpaque = true
-        background = if (me) JBColor(0xEAEEF7, 0x45494A) else JBColor(0xE0EEF7, 0x2d2f30 /*2d2f30*/)
+        background = if (user) JBColor(0xEAEEF7, 0x45494A) else JBColor(0xE0EEF7, 0x2d2f30 /*2d2f30*/)
         border = JBUI.Borders.empty(10, 10, 10, 3)
         layout = BorderLayout(JBUI.scale(7), 1)
 
@@ -44,7 +46,7 @@ class ChatBubble (msg : String, me : Boolean = true): JBPanel<ChatBubble>() {
     }
 
     fun appendMessage(data: String) {
-        component.updateMessage(component.text + data)
+        component.appendMessage(data)
     }
 
 }

--- a/src/main/kotlin/dev/jamiecraane/gptmentorplugin/ui/chat/messages/ChatBubble.kt
+++ b/src/main/kotlin/dev/jamiecraane/gptmentorplugin/ui/chat/messages/ChatBubble.kt
@@ -1,0 +1,50 @@
+package dev.jamiecraane.gptmentorplugin.ui.chat.messages
+
+import com.intellij.ui.JBColor
+import com.intellij.ui.components.JBPanel
+import com.intellij.ui.components.panels.VerticalLayout
+import com.intellij.util.ui.JBUI
+import java.awt.BorderLayout
+import java.awt.Component
+import javax.swing.JEditorPane
+import javax.swing.JPanel
+
+class ChatBubble (msg : String, me : Boolean = true): JBPanel<ChatBubble>() {
+    private val component = MessagePanel()
+
+
+
+    init {
+        var question : String = msg
+
+        isOpaque = true
+        background = if (me) JBColor(0xEAEEF7, 0x45494A) else JBColor(0xE0EEF7, 0x2d2f30 /*2d2f30*/)
+        border = JBUI.Borders.empty(10, 10, 10, 3)
+        layout = BorderLayout(JBUI.scale(7), 1)
+
+        val centerPanel = JPanel(VerticalLayout(JBUI.scale(8)))
+        centerPanel.isOpaque = false
+        centerPanel.border = JBUI.Borders.emptyRight(10)
+        centerPanel.add(createContentComponent(question))
+        add(centerPanel, BorderLayout.CENTER)
+
+    }
+
+    fun createContentComponent(content :String) : Component {
+        component.isEditable = false
+        component.putClientProperty(JEditorPane.HONOR_DISPLAY_PROPERTIES, java.lang.Boolean.TRUE)
+        component.contentType = "text/html; charset=UTF-8"
+        component.isOpaque = false
+        component.border = null
+
+        component.updateMessage(content)
+        component.revalidate()
+        component.repaint()
+        return component
+    }
+
+    fun appendMessage(data: String) {
+        component.updateMessage(component.text + data)
+    }
+
+}

--- a/src/main/kotlin/dev/jamiecraane/gptmentorplugin/ui/chat/messages/ChatBubble.kt
+++ b/src/main/kotlin/dev/jamiecraane/gptmentorplugin/ui/chat/messages/ChatBubble.kt
@@ -12,19 +12,16 @@ import javax.swing.JTextArea
 
 class ChatBubble (msg : String, user : Boolean = true): JBPanel<ChatBubble>() {
     val isUser = user
-    private val responseComponent = MessagePanel()
-    private val questionComponent = JTextArea()
-
-
-
-
+    // responseComponent and questionComponent are mutually exclusive (one will be null)
+    private val responseComponent: MessagePanel? = if (!isUser) MessagePanel() else null
+    private val questionComponent: JTextArea? = if (isUser) JTextArea() else null
 
 
     init {
         val question : String = msg
 
         isOpaque = true
-        background = if (user) JBColor(0xEAEEF7, 0x45494A) else JBColor(0xE0EEF7, 0x2d2f30 /*2d2f30*/)
+        background = if (user) JBColor(0xEAEEF7, 0x45494A) else JBColor(0xE0EEF7, 0x2d2f30)
         border = JBUI.Borders.empty(10, 10, 10, 3)
         layout = BorderLayout(JBUI.scale(7), 1)
 
@@ -38,11 +35,12 @@ class ChatBubble (msg : String, user : Boolean = true): JBPanel<ChatBubble>() {
 
     fun createContentComponent(content :String) : Component {
         val component = if (isUser) questionComponent else responseComponent
-        responseComponent.contentType = "text/html; charset=UTF-8"
-        responseComponent.updateMessage(content)
-        questionComponent.append(content)
-        questionComponent.lineWrap = true
-        questionComponent.wrapStyleWord = true
+        component!! // Assuming that isUser must be true or false making question and response mutually exclusive
+        responseComponent?.contentType  = "text/html; charset=UTF-8"
+        responseComponent?.updateMessage(content)
+        questionComponent?.append(content)
+        questionComponent?.lineWrap = true
+        questionComponent?.wrapStyleWord = true
 
         component.isEditable = false
         component.putClientProperty(JEditorPane.HONOR_DISPLAY_PROPERTIES, java.lang.Boolean.TRUE)
@@ -55,7 +53,7 @@ class ChatBubble (msg : String, user : Boolean = true): JBPanel<ChatBubble>() {
     }
 
     fun appendMessage(data: String) {
-        responseComponent.appendMessage(data)
+        responseComponent?.appendMessage(data)
     }
 
 }

--- a/src/main/kotlin/dev/jamiecraane/gptmentorplugin/ui/chat/messages/ChatBubbleGroup.kt
+++ b/src/main/kotlin/dev/jamiecraane/gptmentorplugin/ui/chat/messages/ChatBubbleGroup.kt
@@ -7,7 +7,7 @@ import com.intellij.util.ui.JBUI
 import javax.swing.JPanel
 
 
-class chatBubbleGroup : JBPanel<chatBubbleGroup>(), NullableComponent {
+class ChatBubbleGroup : JBPanel<ChatBubbleGroup>(), NullableComponent {
 
     val myList = JPanel(VerticalLayout(JBUI.scale(10)))
     var lastComponent: ChatBubble? = null

--- a/src/main/kotlin/dev/jamiecraane/gptmentorplugin/ui/chat/messages/ChatBubbleGroup.kt
+++ b/src/main/kotlin/dev/jamiecraane/gptmentorplugin/ui/chat/messages/ChatBubbleGroup.kt
@@ -31,4 +31,8 @@ class ChatBubbleGroup : JBPanel<ChatBubbleGroup>(), NullableComponent {
             layout.addLayoutComponent(null, myList.getComponent(i))
         }
     }
+
+    fun newBubble(text: String) {
+        ChatBubble(text).also { myList.add(it) }
+    }
 }

--- a/src/main/kotlin/dev/jamiecraane/gptmentorplugin/ui/chat/messages/ChatBubbleGroup.kt
+++ b/src/main/kotlin/dev/jamiecraane/gptmentorplugin/ui/chat/messages/ChatBubbleGroup.kt
@@ -1,0 +1,34 @@
+package dev.jamiecraane.gptmentorplugin.ui.chat.messages
+
+import com.intellij.openapi.ui.NullableComponent
+import com.intellij.ui.components.JBPanel
+import com.intellij.ui.components.panels.VerticalLayout
+import com.intellij.util.ui.JBUI
+import javax.swing.JPanel
+
+
+class chatBubbleGroup : JBPanel<chatBubbleGroup>(), NullableComponent {
+
+    val myList = JPanel(VerticalLayout(JBUI.scale(10)))
+    var lastComponent: ChatBubble? = null
+
+    override fun isNull(): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    fun add(message_component : ChatBubble) {
+        myList.add(message_component)
+        lastComponent = message_component
+        updateLayout()
+        updateUI()
+    }
+
+    fun updateLayout(){
+        val layout = myList.layout
+        val componentCount = myList.componentCount
+        for (i in 0 until componentCount) {
+            layout.removeLayoutComponent(myList.getComponent(i))
+            layout.addLayoutComponent(null, myList.getComponent(i))
+        }
+    }
+}

--- a/src/main/kotlin/dev/jamiecraane/gptmentorplugin/ui/chat/messages/ChatBubbleGroup.kt
+++ b/src/main/kotlin/dev/jamiecraane/gptmentorplugin/ui/chat/messages/ChatBubbleGroup.kt
@@ -32,7 +32,7 @@ class ChatBubbleGroup : JBPanel<ChatBubbleGroup>(), NullableComponent {
         }
     }
 
-    fun newBubble(text: String) {
-        ChatBubble(text).also { myList.add(it) }
+    fun newBubble(text: String, isUser: Boolean = true) {
+        ChatBubble(text, isUser).also { add(it) }
     }
 }

--- a/src/main/kotlin/dev/jamiecraane/gptmentorplugin/ui/chat/messages/MessagePanel.kt
+++ b/src/main/kotlin/dev/jamiecraane/gptmentorplugin/ui/chat/messages/MessagePanel.kt
@@ -1,0 +1,24 @@
+package dev.jamiecraane.gptmentorplugin.ui.chat.messages
+
+import com.intellij.util.ui.HtmlPanel
+import com.intellij.util.ui.UIUtil
+import org.jetbrains.annotations.Nls
+import java.awt.Font
+
+class MessagePanel : HtmlPanel() {
+
+    private var msg = ""
+
+    @Nls
+    override fun getBody(): String {
+        return if (msg.isNullOrEmpty()) "" else msg
+    }
+    override fun getBodyFont(): Font {
+        return UIUtil.getLabelFont()
+    }
+
+    fun updateMessage(updateMessage: String) {
+        this.msg = updateMessage
+        update()
+    }
+}

--- a/src/main/kotlin/dev/jamiecraane/gptmentorplugin/ui/chat/messages/MessagePanel.kt
+++ b/src/main/kotlin/dev/jamiecraane/gptmentorplugin/ui/chat/messages/MessagePanel.kt
@@ -2,6 +2,9 @@ package dev.jamiecraane.gptmentorplugin.ui.chat.messages
 
 import com.intellij.util.ui.HtmlPanel
 import com.intellij.util.ui.UIUtil
+import com.vladsch.flexmark.html.HtmlRenderer
+import com.vladsch.flexmark.parser.Parser
+import com.vladsch.flexmark.util.ast.Node
 import org.jetbrains.annotations.Nls
 import java.awt.Font
 
@@ -12,7 +15,7 @@ class MessagePanel : HtmlPanel() {
 
     @Nls
     override fun getBody(): String {
-        return if (msg.isNullOrEmpty()) "" else msg
+        return if (msg.isNullOrEmpty()) "" else convertMarkdownToHTML(msg)
     }
     override fun getBodyFont(): Font {
         return UIUtil.getLabelFont()
@@ -25,5 +28,12 @@ class MessagePanel : HtmlPanel() {
 
     fun appendMessage(newData: String){
         updateMessage(msg + newData)
+    }
+
+    private fun convertMarkdownToHTML(markdown: String) : String{
+        val parser: Parser = Parser.builder().build()
+        val document: Node = parser.parse(markdown)
+        val renderer: HtmlRenderer = HtmlRenderer.builder().build()
+        return renderer.render(document)
     }
 }

--- a/src/main/kotlin/dev/jamiecraane/gptmentorplugin/ui/chat/messages/MessagePanel.kt
+++ b/src/main/kotlin/dev/jamiecraane/gptmentorplugin/ui/chat/messages/MessagePanel.kt
@@ -8,7 +8,7 @@ import com.vladsch.flexmark.util.ast.Node
 import org.jetbrains.annotations.Nls
 import java.awt.Font
 
-class MessagePanel : HtmlPanel() {
+class MessagePanel() : HtmlPanel() {
 
 
     private var msg = ""

--- a/src/main/kotlin/dev/jamiecraane/gptmentorplugin/ui/chat/messages/MessagePanel.kt
+++ b/src/main/kotlin/dev/jamiecraane/gptmentorplugin/ui/chat/messages/MessagePanel.kt
@@ -7,6 +7,7 @@ import java.awt.Font
 
 class MessagePanel : HtmlPanel() {
 
+
     private var msg = ""
 
     @Nls
@@ -18,7 +19,11 @@ class MessagePanel : HtmlPanel() {
     }
 
     fun updateMessage(updateMessage: String) {
-        this.msg = updateMessage
+        msg = updateMessage
         update()
+    }
+
+    fun appendMessage(newData: String){
+        updateMessage(msg + newData)
     }
 }


### PR DESCRIPTION
Hey I really love your plugin; having GPT directly inside my IDE is a major bump in my efficacy. I enjoyed working on this PR.

 
![updated](https://github.com/jcraane/gpt-mentor-plugin/assets/108432252/b541150d-fc97-496a-8ca8-8a3358506415)

## Let me explain the changes to the code base 

### Messages package 

**Path** : `dev/jamiecraane/gptmentorplugin/ui/chat/messages`

- ChatBubble.kt
- ChatBubbleGroup.kt
- MessagePanel.kt

![explanation-diag](https://github.com/jcraane/gpt-mentor-plugin/assets/108432252/d153be8a-19ec-4061-932d-a034ac81471e)

-  `MessagePanel` is a child of HTMLPanel. GPT responses are typically in Markdown so I simply converted the markdown to HTML. This is only used for GPT responses
- `ChatBubble` holds the MessagePanel/JTextArea

## Chat History

![history-tab](https://github.com/jcraane/gpt-mentor-plugin/assets/108432252/eb7b15cd-d25e-4dea-b460-7b2a8b672587)

